### PR TITLE
fix: resolve iOS build failure with koinViewModel workaround

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -54,6 +54,7 @@ kotlin {
             implementation(compose.components.resources)
             implementation(compose.components.uiToolingPreview)
             implementation(libs.androidx.lifecycle.viewmodel)
+            implementation(libs.androidx.lifecycle.viewmodel.compose)
             implementation(libs.androidx.lifecycle.runtimeCompose)
             implementation(libs.androidx.navigation.compose)
             implementation(libs.ktor.client.core)

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/App.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/App.kt
@@ -16,9 +16,11 @@ import jp.kztproject.simplepodcastplayer.screen.PodcastListScreen
 import jp.kztproject.simplepodcastplayer.screen.PodcastListViewModel
 import jp.kztproject.simplepodcastplayer.screen.PodcastSearchScreen
 import jp.kztproject.simplepodcastplayer.screen.rememberPlayerViewModel
+import jp.kztproject.simplepodcastplayer.data.repository.PodcastRepository
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.KoinApplication
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
+import androidx.lifecycle.viewmodel.compose.viewModel
 
 @Composable
 @Preview
@@ -70,7 +72,8 @@ fun App() {
                     // We need to get the podcast from the database using selectedPodcastId
                     selectedPodcastId.value?.let { podcastId ->
                         // Get the podcast from the view model
-                        val listViewModel: PodcastListViewModel = koinViewModel()
+                        val podcastRepository: PodcastRepository = koinInject()
+                        val listViewModel: PodcastListViewModel = viewModel { PodcastListViewModel(podcastRepository) }
                         listViewModel.getPodcastById(podcastId)?.let { podcast ->
                             PodcastDetailScreen(
                                 podcast = podcast,

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastDetailScreen.kt
@@ -55,11 +55,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable
-fun PodcastDetailScreen(
-    podcast: Podcast,
-    onNavigateBack: () -> Unit,
-    onNavigateToPlayer: (Episode, Podcast) -> Unit,
-) {
+fun PodcastDetailScreen(podcast: Podcast, onNavigateBack: () -> Unit, onNavigateToPlayer: (Episode, Podcast) -> Unit) {
     val rssService: IRssService = koinInject()
     val podcastRepository: PodcastRepository = koinInject()
     val downloadRepository: IDownloadRepository = koinInject()

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastDetailScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastDetailScreen.kt
@@ -42,22 +42,35 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import jp.kztproject.simplepodcastplayer.data.Episode
 import jp.kztproject.simplepodcastplayer.data.EpisodeDisplayModel
+import jp.kztproject.simplepodcastplayer.data.IRssService
 import jp.kztproject.simplepodcastplayer.data.Podcast
+import jp.kztproject.simplepodcastplayer.data.repository.IDownloadRepository
+import jp.kztproject.simplepodcastplayer.data.repository.PodcastRepository
 import jp.kztproject.simplepodcastplayer.download.DownloadState
 import org.jetbrains.compose.ui.tooling.preview.Preview
-import org.koin.compose.viewmodel.koinViewModel
-import org.koin.core.parameter.parametersOf
+import org.koin.compose.koinInject
 
 @Composable
 fun PodcastDetailScreen(
     podcast: Podcast,
     onNavigateBack: () -> Unit,
     onNavigateToPlayer: (Episode, Podcast) -> Unit,
-    viewModel: PodcastDetailViewModel = koinViewModel { parametersOf(onNavigateToPlayer) },
 ) {
+    val rssService: IRssService = koinInject()
+    val podcastRepository: PodcastRepository = koinInject()
+    val downloadRepository: IDownloadRepository = koinInject()
+    val viewModel: PodcastDetailViewModel = viewModel {
+        PodcastDetailViewModel(
+            rssService = rssService,
+            podcastRepository = podcastRepository,
+            downloadRepository = downloadRepository,
+            onNavigateToPlayer = onNavigateToPlayer,
+        )
+    }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
     val snackbarHostState = remember { SnackbarHostState() }
 

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastListScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastListScreen.kt
@@ -32,13 +32,16 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
 import jp.kztproject.simplepodcastplayer.data.database.entity.PodcastEntity
-import org.koin.compose.viewmodel.koinViewModel
+import jp.kztproject.simplepodcastplayer.data.repository.PodcastRepository
+import org.koin.compose.koinInject
 
 @Composable
 fun PodcastListScreen(onNavigateToSearch: () -> Unit, onPodcastClick: (Long) -> Unit) {
-    val viewModel: PodcastListViewModel = koinViewModel()
+    val podcastRepository: PodcastRepository = koinInject()
+    val viewModel: PodcastListViewModel = viewModel { PodcastListViewModel(podcastRepository) }
     val uiState by viewModel.uiState.collectAsStateWithLifecycle()
 
     Column(

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastSearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastSearchScreen.kt
@@ -36,17 +36,20 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.text.style.TextOverflow
 import androidx.compose.ui.unit.dp
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.lifecycle.viewmodel.compose.viewModel
 import coil3.compose.AsyncImage
+import jp.kztproject.simplepodcastplayer.data.IAppleSearchApiClient
 import jp.kztproject.simplepodcastplayer.data.Podcast
 import org.jetbrains.compose.ui.tooling.preview.Preview
-import org.koin.compose.viewmodel.koinViewModel
+import org.koin.compose.koinInject
 
 @Composable
 fun PodcastSearchScreen(
     onNavigateToList: () -> Unit,
     onNavigateToDetail: (Podcast) -> Unit,
-    viewModel: PodcastSearchViewModel = koinViewModel(),
 ) {
+    val apiClient: IAppleSearchApiClient = koinInject()
+    val viewModel: PodcastSearchViewModel = viewModel { PodcastSearchViewModel(apiClient) }
     val podcasts by viewModel.podcasts.collectAsStateWithLifecycle()
     val isLoading by viewModel.isLoading.collectAsStateWithLifecycle()
     val errorMessage by viewModel.errorMessage.collectAsStateWithLifecycle()

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastSearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastSearchScreen.kt
@@ -44,10 +44,7 @@ import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.koinInject
 
 @Composable
-fun PodcastSearchScreen(
-    onNavigateToList: () -> Unit,
-    onNavigateToDetail: (Podcast) -> Unit,
-) {
+fun PodcastSearchScreen(onNavigateToList: () -> Unit, onNavigateToDetail: (Podcast) -> Unit) {
     val apiClient: IAppleSearchApiClient = koinInject()
     val viewModel: PodcastSearchViewModel = viewModel { PodcastSearchViewModel(apiClient) }
     val podcasts by viewModel.podcasts.collectAsStateWithLifecycle()

--- a/composeApp/src/iosMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PlayerViewModelImpl.ios.kt
+++ b/composeApp/src/iosMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PlayerViewModelImpl.ios.kt
@@ -3,15 +3,17 @@ package jp.kztproject.simplepodcastplayer.screen
 import jp.kztproject.simplepodcastplayer.data.Episode
 import jp.kztproject.simplepodcastplayer.data.Podcast
 import jp.kztproject.simplepodcastplayer.data.repository.DownloadRepository
+import jp.kztproject.simplepodcastplayer.data.repository.IDownloadRepository
 import jp.kztproject.simplepodcastplayer.data.repository.PlaybackRepository
 import jp.kztproject.simplepodcastplayer.player.AudioPlayer
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
 
-class PlayerViewModelImpl : BasePlayerViewModel() {
+class PlayerViewModelImpl(
+    override val playbackRepository: PlaybackRepository,
+    override val downloadRepository: IDownloadRepository,
+) : BasePlayerViewModel() {
     override val audioPlayer = AudioPlayer()
-    override val playbackRepository = PlaybackRepository()
-    override val downloadRepository = DownloadRepository()
     override val coroutineScope = CoroutineScope(Dispatchers.Main)
 
     override fun play() {

--- a/composeApp/src/iosMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PlayerViewModelImpl.ios.kt
+++ b/composeApp/src/iosMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PlayerViewModelImpl.ios.kt
@@ -2,7 +2,6 @@ package jp.kztproject.simplepodcastplayer.screen
 
 import jp.kztproject.simplepodcastplayer.data.Episode
 import jp.kztproject.simplepodcastplayer.data.Podcast
-import jp.kztproject.simplepodcastplayer.data.repository.DownloadRepository
 import jp.kztproject.simplepodcastplayer.data.repository.IDownloadRepository
 import jp.kztproject.simplepodcastplayer.data.repository.PlaybackRepository
 import jp.kztproject.simplepodcastplayer.player.AudioPlayer

--- a/composeApp/src/iosMain/kotlin/jp/kztproject/simplepodcastplayer/screen/RememberPlayerViewModel.ios.kt
+++ b/composeApp/src/iosMain/kotlin/jp/kztproject/simplepodcastplayer/screen/RememberPlayerViewModel.ios.kt
@@ -4,11 +4,20 @@ import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import jp.kztproject.simplepodcastplayer.data.Episode
 import jp.kztproject.simplepodcastplayer.data.Podcast
+import jp.kztproject.simplepodcastplayer.data.repository.IDownloadRepository
+import jp.kztproject.simplepodcastplayer.data.repository.PlaybackRepository
+import org.koin.compose.koinInject
 
 @Composable
 actual fun rememberPlayerViewModel(episode: Episode, podcast: Podcast): PlayerViewModel {
+    val playbackRepository: PlaybackRepository = koinInject()
+    val downloadRepository: IDownloadRepository = koinInject()
+
     val viewModel = remember(episode.id) {
-        PlayerViewModelImpl().apply {
+        PlayerViewModelImpl(
+            playbackRepository = playbackRepository,
+            downloadRepository = downloadRepository,
+        ).apply {
             loadEpisode(episode, podcast)
         }
     }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -40,6 +40,7 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-activity-compose = { module = "androidx.activity:activity-compose", version.ref = "androidx-activity" }
 androidx-lifecycle-viewmodel = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel", version.ref = "androidx-lifecycle" }
+androidx-lifecycle-viewmodel-compose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-viewmodel-compose", version.ref = "androidx-lifecycle" }
 androidx-lifecycle-runtimeCompose = { module = "org.jetbrains.androidx.lifecycle:lifecycle-runtime-compose", version.ref = "androidx-lifecycle" }
 androidx-navigation-compose = { module = "org.jetbrains.androidx.navigation:navigation-compose", version.ref = "androidx-navigation" }
 ktor-client-core = { module = "io.ktor:ktor-client-core", version.ref = "ktor" }


### PR DESCRIPTION
## Summary
- Fix iOS build failure caused by Koin 4.0 `koinViewModel` linking issue
- Replace `koinViewModel` calls with `viewModel {}` pattern as workaround
- Fix `PlayerViewModelImpl.ios.kt` missing constructor parameters

## Background
This is a known Koin issue ([InsertKoinIO/koin#2175](https://github.com/InsertKoinIO/koin/issues/2175)) that causes iOS builds to fail with:
```
Undefined symbols for architecture arm64:
"_kfun:androidx.lifecycle.viewmodel.compose#LocalViewModelStoreOwner..."
```

The fix is planned for Koin 4.1.0.

## Changes
| File | Change |
|------|--------|
| `App.kt` | Replace `koinViewModel` with `viewModel {}` |
| `PodcastListScreen.kt` | Replace `koinViewModel` with `viewModel {}` |
| `PodcastSearchScreen.kt` | Replace `koinViewModel` with `viewModel {}` |
| `PodcastDetailScreen.kt` | Replace `koinViewModel` with `viewModel {}` |
| `PlayerViewModelImpl.ios.kt` | Add missing constructor parameters |
| `RememberPlayerViewModel.ios.kt` | Use `koinInject` for DI |
| `build.gradle.kts` | Add `lifecycle-viewmodel-compose` dependency |
| `libs.versions.toml` | Add `lifecycle-viewmodel-compose` library |

## Test plan
- [x] iOS build succeeds locally
- [x] Android build succeeds locally
- [ ] iOS build workflow passes (trigger manually after merge)
- [ ] Android build workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)