### PR TITLE
fix: update iOS simulator from iPhone 16 to iPhone 15 Pro in CI

### DIFF
--- a/.github/workflows/build-check-ios.yml
+++ b/.github/workflows/build-check-ios.yml
@@ -43,7 +43,7 @@ jobs:
         xcodebuild -project iosApp/iosApp.xcodeproj \
           -scheme iosApp \
           -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 16,OS=latest' \
+          -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=latest' \
           -allowProvisioningUpdates \
           CODE_SIGNING_ALLOWED=NO \
           build


### PR DESCRIPTION
## Summary
Fix iOS build workflow failure by updating the simulator device name from iPhone 16 to iPhone 15 Pro.

## Background
The iOS build check workflow was failing with error code 70 because the specified `iPhone 16` simulator is not available in the Xcode 16.4 environment on GitHub Actions `macos-latest` runners.

```
xcodebuild: error: Unable to find a device matching the provided destination specifier:
    { platform:iOS Simulator, OS:latest, name:iPhone 16 }
```

## Changes
- Updated `.github/workflows/build-check-ios.yml` to use `iPhone 15 Pro` instead of `iPhone 16`

## Test plan
- [ ] CI workflow passes after merge

## References
- Failed workflow run: https://github.com/kseito/SimplePodcastPlayer/actions/runs/21325511909/job/61381865820

🤖 Generated with [Claude Code](https://claude.com/claude-code)