### PR TITLE
fix: use generic iOS Simulator destination in CI

### DIFF
--- a/.github/workflows/build-check-ios.yml
+++ b/.github/workflows/build-check-ios.yml
@@ -43,7 +43,7 @@ jobs:
         xcodebuild -project iosApp/iosApp.xcodeproj \
           -scheme iosApp \
           -configuration Debug \
-          -destination 'platform=iOS Simulator,name=iPhone 15 Pro,OS=latest' \
+          -destination 'generic/platform=iOS Simulator' \
           -allowProvisioningUpdates \
           CODE_SIGNING_ALLOWED=NO \
           build


### PR DESCRIPTION
## Summary
- Fixed iOS CI build failures caused by unavailable simulator devices
- Changed from specific device name (`iPhone 15 Pro`) to generic platform specification (`generic/platform=iOS Simulator`)
- This makes the CI more resilient to GitHub Actions environment changes

## Problem
The iOS build check workflow was consistently failing because specific simulator devices (iPhone 16, iPhone 15 Pro) were not available in the GitHub Actions macOS environment.

## Solution
Use `generic/platform=iOS Simulator` instead of specifying a particular device name. This allows xcodebuild to automatically select an available iOS simulator.

## Test plan
- [ ] Verify iOS build workflow passes in CI
- [ ] Confirm workflow runs successfully on schedule and manual trigger

🤖 Generated with [Claude Code](https://claude.com/claude-code)