### PR TITLE
fix: apply navigationBarsPadding to PlayerScreen bottom controls

### DIFF
--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PlayerScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PlayerScreen.kt
@@ -7,6 +7,7 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.rememberScrollState
@@ -177,6 +178,7 @@ private fun PlaybackControls(state: PlaybackState, actions: PlaybackActions) {
     Column(
         modifier = Modifier
             .fillMaxWidth()
+            .navigationBarsPadding()
             .padding(horizontal = 24.dp)
             .padding(vertical = 16.dp),
         horizontalAlignment = Alignment.CenterHorizontally,


### PR DESCRIPTION
Add navigationBarsPadding() to PlaybackControls to ensure the bottom bar content sits above the navigation bar on Edge to Edge displays.