### PR TITLE
fix: drop iosX64 target to fix iOS build with Compose 1.11.0

### DIFF
--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -21,7 +21,6 @@ kotlin {
     }
 
     listOf(
-        iosX64(),
         iosArm64(),
         iosSimulatorArm64(),
     ).forEach { iosTarget ->
@@ -124,7 +123,6 @@ dependencies {
     debugImplementation(compose.uiTooling)
     add("kspAndroid", libs.room.compiler)
     add("kspIosSimulatorArm64", libs.room.compiler)
-    add("kspIosX64", libs.room.compiler)
     add("kspIosArm64", libs.room.compiler)
 }
 


### PR DESCRIPTION
## 概要

スケジュール実行されている iOS ビルドチェック ([run #26732602075](https://github.com/kseito/SimplePodcastPlayer/actions/runs/26732602075)) が依存解決エラーで失敗していたため修正します。

## 原因

Compose Multiplatform **1.11.0** から `iosX64`（Intel Mac シミュレータ）向け artifact の公開が廃止されました。`composeApp/build.gradle.kts` が `iosX64()` ターゲットを宣言したままだったため、`coil-compose:3.4.0` が依存する `org.jetbrains.compose.foundation:foundation:1.11.0` の `ios_x64` variant が見つからず、`xcodebuild` 経由の Kotlin フレームワークビルドが失敗していました。

```
> Could not resolve org.jetbrains.compose.foundation:foundation:1.9.3.
  > No matching variant of org.jetbrains.compose.foundation:foundation:1.11.0 was found.
    ... attribute 'org.jetbrains.kotlin.native.target' with value 'ios_x64'
```

## 変更内容

- KMP ターゲットリストから `iosX64()` を削除
- 紐づく `add("kspIosX64", libs.room.compiler)`（Room KSP 設定）を削除

CI ランナー（`macos-latest`）は Apple Silicon のため、シミュレータビルドは `iosSimulatorArm64` で行われ `iosX64` は不要です。

## 動作確認

- `./gradlew :composeApp:dependencies --configuration iosSimulatorArm64CompileKlibraries` で依存解決が成功することを確認
- `./gradlew :composeApp:linkDebugFrameworkIosSimulatorArm64` で `BUILD SUCCESSFUL` を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)