### PR TITLE
Add デバッグAPKをGitHub Releaseに添付・公開するGHA

### DIFF
--- a/.github/workflows/release-debug-apk.yml
+++ b/.github/workflows/release-debug-apk.yml
@@ -1,0 +1,55 @@
+name: Release Debug APK
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Release tag name (e.g. debug-1.0.0)'
+        required: true
+        type: string
+
+permissions:
+  contents: write
+
+jobs:
+  release-debug-apk:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v6
+
+    - name: Set up JDK 17
+      uses: actions/setup-java@v5
+      with:
+        java-version: '17'
+        distribution: 'temurin'
+
+    - name: Cache Gradle packages
+      uses: actions/cache@v5
+      with:
+        path: |
+          ~/.gradle/caches
+          ~/.gradle/wrapper
+        key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+        restore-keys: |
+          ${{ runner.os }}-gradle-
+
+    - name: Grant execute permission for gradlew
+      run: chmod +x gradlew
+
+    - name: Decode debug keystore
+      run: echo "${{ secrets.DEBUG_KEYSTORE_BASE64 }}" | base64 -d > debug.keystore
+
+    - name: Build debug APK
+      run: ./gradlew assembleDebug
+
+    - name: Create GitHub Release with debug APK
+      env:
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh release create "${{ inputs.tag }}" \
+          composeApp/build/outputs/apk/debug/composeApp-debug.apk \
+          --title "${{ inputs.tag }}" \
+          --generate-notes \
+          --target "${{ github.sha }}"

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 xcuserdata
 !src/**/build/
 local.properties
+debug.keystore
 .idea
 .DS_Store
 captures

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -108,6 +108,19 @@ android {
             excludes += "/META-INF/{AL2.0,LGPL2.1}"
         }
     }
+    signingConfigs {
+        getByName("debug") {
+            // CIで配置した固定keystoreがあればそれで署名し、無ければ
+            // 各自の ~/.android/debug.keystore（AGPデフォルト）を使う
+            val debugKeystore = rootProject.file("debug.keystore")
+            if (debugKeystore.isFile) {
+                storeFile = debugKeystore
+                storePassword = "android"
+                keyAlias = "androiddebugkey"
+                keyPassword = "android"
+            }
+        }
+    }
     buildTypes {
         getByName("release") {
             isMinifyEnabled = false


### PR DESCRIPTION
## Summary
- 手動トリガー（`workflow_dispatch`）でデバッグAPKをビルドし、GitHub Releaseに添付して公開するワークフローを追加
- CIとローカル(Mac)のdebug署名鍵を統一し、相互に上書きインストールできるようにする

## 変更内容
- `.github/workflows/release-debug-apk.yml` を新規追加
  - トリガーは `workflow_dispatch` のみ。`tag`（リリースタグ名）を必須入力として受け取る
  - 既存ワークフロー（`build-check.yml` 等）と同じインライン構成（JDK17 / Gradleキャッシュ）を使用
  - Secret `DEBUG_KEYSTORE_BASE64` をデコードして `debug.keystore` を配置してから `./gradlew assembleDebug` を実行
  - `gh release create` で `composeApp/build/outputs/apk/debug/composeApp-debug.apk` を添付し、`--generate-notes` でリリースノートを自動生成
  - `permissions: contents: write` を付与
- `composeApp/build.gradle.kts`: `debug` signingConfig を追加。リポジトリルートに `debug.keystore` があればそれで署名し、無ければローカルのAGPデフォルト鍵を使う
- `.gitignore`: CIで一時生成する `debug.keystore` を除外

## レビュアー向け補足
- **実行前に GitHub Secret `DEBUG_KEYSTORE_BASE64`（Macの `~/.android/debug.keystore` をbase64化したもの）の登録が必要です**
  - `base64 -i ~/.android/debug.keystore | pbcopy` でコピーし、Settings → Secrets and variables → Actions に登録
- debug keystoreの標準パスワード(`android`)はハードコードしているが、これは公開情報であり機密ではない
- タグは入力必須。`versionName` から自動生成する形が良ければ変更可能
- ローカルで `./gradlew :composeApp:assembleDebug` がBUILD SUCCESSFULになること、APKが `composeApp/build/outputs/apk/debug/composeApp-debug.apk` に出力されることを確認済み

## Test plan
- [ ] GitHub Actions上で `Release Debug APK` を `workflow_dispatch` で実行し、Releaseが作成され `composeApp-debug.apk` が添付されることを確認
- [ ] 出力APKの署名SHA-1がローカルと一致することを確認
- [ ] 既存のローカルビルドdebug版がインストールされた端末に、CI出力APKを上書きインストールできることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)