### PR TITLE
refactor: 非推奨APIを後継APIへ置き換え

### DIFF
--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/App.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/App.kt
@@ -18,13 +18,16 @@ import jp.kztproject.simplepodcastplayer.screen.PodcastSearchScreen
 import jp.kztproject.simplepodcastplayer.screen.rememberPlayerViewModel
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.KoinApplication
+import org.koin.dsl.koinConfiguration
 
 @Composable
 @Preview
 fun App() {
-    KoinApplication(application = {
-        modules(appModule)
-    }) {
+    KoinApplication(
+        configuration = koinConfiguration {
+            modules(appModule)
+        },
+    ) {
         MaterialTheme {
             val navController = rememberNavController()
             val selectedPodcast = remember { mutableStateOf<Podcast?>(null) }

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastSearchViewModel.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastSearchViewModel.kt
@@ -25,9 +25,6 @@ class PodcastSearchViewModel(private val apiClient: IAppleSearchApiClient) : Vie
     private val _errorMessage = MutableStateFlow<String?>(null)
     val errorMessage: StateFlow<String?> = _errorMessage.asStateFlow()
 
-    @Deprecated("Use searchQuery instead")
-    val text = MutableStateFlow("")
-
     fun updateSearchQuery(query: String) {
         _searchQuery.update { query }
     }


### PR DESCRIPTION
## 概要

コンパイル時の deprecation 警告を解消するため、アプリの Kotlin コードで実際に使用していた非推奨 API を後継 API へ置き換えました。

調査(Explore エージェント + 実コードでの裏取り)の結果、アプリの Kotlin コード内で実際に非推奨 API を使っていたのは **2 箇所** でした。

## 変更内容

- **`App.kt`**: `KoinApplication` の `KoinAppDeclaration` ラムダ版(非推奨)を、Koin 4.2.1 推奨の `koinConfiguration {}` DSL 版(`configuration` 引数)に置き換え
- **`PodcastSearchViewModel.kt`**: 未使用の `@Deprecated val text` フィールドを削除(後継の `searchQuery` に移行済み)

## スコープ外(今回は対応しない)

- `expect/actual` の Beta 警告(非推奨ではなく Beta 機能の警告)
- ビルド設定の非推奨警告(`android.builtInKotlin=false` / `android.newDsl=false` 等)。これらは AGP 9.0 互換の意図的なワークアラウンド(コミット `a47e1dd`)やプラグイン内部由来で、根本対応は KMP 構造移行に集約されるため別タスクとする

## 検証

- `./gradlew :composeApp:compileDebugKotlinAndroid` — 成功(Koin / `text` の deprecation 警告が消失)
- `./gradlew :composeApp:testDebugUnitTest` — 成功(既存テストはすべてパス)
- `./gradlew spotlessApply` / `./gradlew detekt` — 成功

🤖 Generated with [Claude Code](https://claude.com/claude-code)