### PR TITLE
メインカラーをオレンジ基調に変更

### DIFF
--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/App.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/App.kt
@@ -1,6 +1,5 @@
 package jp.kztproject.simplepodcastplayer
 
-import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
@@ -16,6 +15,7 @@ import jp.kztproject.simplepodcastplayer.screen.PodcastDetailScreen
 import jp.kztproject.simplepodcastplayer.screen.PodcastListScreen
 import jp.kztproject.simplepodcastplayer.screen.PodcastSearchScreen
 import jp.kztproject.simplepodcastplayer.screen.rememberPlayerViewModel
+import jp.kztproject.simplepodcastplayer.ui.theme.AppTheme
 import org.jetbrains.compose.ui.tooling.preview.Preview
 import org.koin.compose.KoinApplication
 import org.koin.dsl.koinConfiguration
@@ -28,7 +28,7 @@ fun App() {
             modules(appModule)
         },
     ) {
-        MaterialTheme {
+        AppTheme {
             val navController = rememberNavController()
             val selectedPodcast = remember { mutableStateOf<Podcast?>(null) }
             val selectedPodcastId = remember { mutableStateOf<Long?>(null) }

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/App.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/App.kt
@@ -1,8 +1,12 @@
 package jp.kztproject.simplepodcastplayer
 
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
+import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
@@ -29,78 +33,83 @@ fun App() {
         },
     ) {
         AppTheme {
-            val navController = rememberNavController()
-            val selectedPodcast = remember { mutableStateOf<Podcast?>(null) }
-            val selectedPodcastId = remember { mutableStateOf<Long?>(null) }
-            val selectedEpisode = remember { mutableStateOf<Episode?>(null) }
-            val selectedEpisodePodcast = remember { mutableStateOf<Podcast?>(null) }
+            Surface(
+                modifier = Modifier.fillMaxSize(),
+                color = MaterialTheme.colorScheme.background,
+            ) {
+                val navController = rememberNavController()
+                val selectedPodcast = remember { mutableStateOf<Podcast?>(null) }
+                val selectedPodcastId = remember { mutableStateOf<Long?>(null) }
+                val selectedEpisode = remember { mutableStateOf<Episode?>(null) }
+                val selectedEpisodePodcast = remember { mutableStateOf<Podcast?>(null) }
 
-            NavHost(navController = navController, startDestination = "list") {
-                composable("list") {
-                    PodcastListScreen(
-                        onNavigateToSearch = { navController.navigate("search") },
-                        onNavigateToInProgress = { navController.navigate("in_progress") },
-                        onPodcastClick = { podcastId ->
-                            selectedPodcastId.value = podcastId
-                            navController.navigate("list_detail")
-                        },
-                    )
-                }
-                composable("search") {
-                    PodcastSearchScreen(
-                        onNavigateToList = { navController.navigate("list") },
-                        onNavigateToDetail = { podcast ->
-                            selectedPodcast.value = podcast
-                            navController.navigate("detail")
-                        },
-                    )
-                }
-                composable("detail") {
-                    selectedPodcast.value?.let { podcast ->
-                        PodcastDetailScreen(
-                            podcast = podcast,
-                            onNavigateBack = { navController.popBackStack() },
-                            onNavigateToPlayer = { episode, podcastData ->
-                                selectedEpisode.value = episode
-                                selectedEpisodePodcast.value = podcastData
-                                navController.navigate("player")
+                NavHost(navController = navController, startDestination = "list") {
+                    composable("list") {
+                        PodcastListScreen(
+                            onNavigateToSearch = { navController.navigate("search") },
+                            onNavigateToInProgress = { navController.navigate("in_progress") },
+                            onPodcastClick = { podcastId ->
+                                selectedPodcastId.value = podcastId
+                                navController.navigate("list_detail")
                             },
                         )
                     }
-                }
-                composable("list_detail") {
-                    selectedPodcastId.value?.let { podcastId ->
-                        PodcastDetailScreen(
-                            podcastId = podcastId,
-                            onNavigateBack = { navController.popBackStack() },
-                            onNavigateToPlayer = { episode, podcastData ->
-                                selectedEpisode.value = episode
-                                selectedEpisodePodcast.value = podcastData
-                                navController.navigate("player")
+                    composable("search") {
+                        PodcastSearchScreen(
+                            onNavigateToList = { navController.navigate("list") },
+                            onNavigateToDetail = { podcast ->
+                                selectedPodcast.value = podcast
+                                navController.navigate("detail")
                             },
                         )
                     }
-                }
-                composable("player") {
-                    selectedEpisode.value?.let { episode ->
-                        selectedEpisodePodcast.value?.let { podcast ->
-                            val viewModel = rememberPlayerViewModel(episode, podcast)
-                            PlayerScreen(
-                                viewModel = viewModel,
+                    composable("detail") {
+                        selectedPodcast.value?.let { podcast ->
+                            PodcastDetailScreen(
+                                podcast = podcast,
                                 onNavigateBack = { navController.popBackStack() },
+                                onNavigateToPlayer = { episode, podcastData ->
+                                    selectedEpisode.value = episode
+                                    selectedEpisodePodcast.value = podcastData
+                                    navController.navigate("player")
+                                },
                             )
                         }
                     }
-                }
-                composable("in_progress") {
-                    InProgressEpisodesScreen(
-                        onNavigateBack = { navController.popBackStack() },
-                        onNavigateToPlayer = { episode, podcast ->
-                            selectedEpisode.value = episode
-                            selectedEpisodePodcast.value = podcast
-                            navController.navigate("player")
-                        },
-                    )
+                    composable("list_detail") {
+                        selectedPodcastId.value?.let { podcastId ->
+                            PodcastDetailScreen(
+                                podcastId = podcastId,
+                                onNavigateBack = { navController.popBackStack() },
+                                onNavigateToPlayer = { episode, podcastData ->
+                                    selectedEpisode.value = episode
+                                    selectedEpisodePodcast.value = podcastData
+                                    navController.navigate("player")
+                                },
+                            )
+                        }
+                    }
+                    composable("player") {
+                        selectedEpisode.value?.let { episode ->
+                            selectedEpisodePodcast.value?.let { podcast ->
+                                val viewModel = rememberPlayerViewModel(episode, podcast)
+                                PlayerScreen(
+                                    viewModel = viewModel,
+                                    onNavigateBack = { navController.popBackStack() },
+                                )
+                            }
+                        }
+                    }
+                    composable("in_progress") {
+                        InProgressEpisodesScreen(
+                            onNavigateBack = { navController.popBackStack() },
+                            onNavigateToPlayer = { episode, podcast ->
+                                selectedEpisode.value = episode
+                                selectedEpisodePodcast.value = podcast
+                                navController.navigate("player")
+                            },
+                        )
+                    }
                 }
             }
         }

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/ui/theme/Theme.kt
@@ -1,0 +1,61 @@
+package jp.kztproject.simplepodcastplayer.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Surface
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+
+private val LightColorScheme = lightColorScheme(
+    primary = Color(0xFFE65100),
+    onPrimary = Color(0xFFFFFFFF),
+    primaryContainer = Color(0xFFFFDBC8),
+    onPrimaryContainer = Color(0xFF311300),
+    secondary = Color(0xFFF57C00),
+    onSecondary = Color(0xFFFFFFFF),
+    secondaryContainer = Color(0xFFFFDCBE),
+    onSecondaryContainer = Color(0xFF2C1600),
+    tertiary = Color(0xFFFFB74D),
+    onTertiary = Color(0xFF422C00),
+    background = Color(0xFFFFFBFF),
+    onBackground = Color(0xFF201A17),
+    surface = Color(0xFFFFFBFF),
+    onSurface = Color(0xFF201A17),
+)
+
+private val DarkColorScheme = darkColorScheme(
+    primary = Color(0xFFFFB68F),
+    onPrimary = Color(0xFF512400),
+    primaryContainer = Color(0xFF733600),
+    onPrimaryContainer = Color(0xFFFFDBC8),
+    secondary = Color(0xFFFFB870),
+    onSecondary = Color(0xFF4A2800),
+    secondaryContainer = Color(0xFF6A3C00),
+    onSecondaryContainer = Color(0xFFFFDCBE),
+    tertiary = Color(0xFFFFB74D),
+    onTertiary = Color(0xFF422C00),
+    background = Color(0xFF201A17),
+    onBackground = Color(0xFFEDE0DA),
+    surface = Color(0xFF201A17),
+    onSurface = Color(0xFFEDE0DA),
+)
+
+@Composable
+fun AppTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit,
+) {
+    MaterialTheme(
+        colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme,
+    ) {
+        Surface(
+            modifier = Modifier.fillMaxSize(),
+            color = MaterialTheme.colorScheme.background,
+            content = content,
+        )
+    }
+}

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/ui/theme/Theme.kt
@@ -1,13 +1,10 @@
 package jp.kztproject.simplepodcastplayer.ui.theme
 
 import androidx.compose.foundation.isSystemInDarkTheme
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.material3.MaterialTheme
-import androidx.compose.material3.Surface
 import androidx.compose.material3.darkColorScheme
 import androidx.compose.material3.lightColorScheme
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 
 private val LightColorScheme = lightColorScheme(
@@ -48,11 +45,6 @@ private val DarkColorScheme = darkColorScheme(
 fun AppTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
     MaterialTheme(
         colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme,
-    ) {
-        Surface(
-            modifier = Modifier.fillMaxSize(),
-            color = MaterialTheme.colorScheme.background,
-            content = content,
-        )
-    }
+        content = content,
+    )
 }

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/ui/theme/Theme.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/ui/theme/Theme.kt
@@ -45,10 +45,7 @@ private val DarkColorScheme = darkColorScheme(
 )
 
 @Composable
-fun AppTheme(
-    darkTheme: Boolean = isSystemInDarkTheme(),
-    content: @Composable () -> Unit,
-) {
+fun AppTheme(darkTheme: Boolean = isSystemInDarkTheme(), content: @Composable () -> Unit) {
     MaterialTheme(
         colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme,
     ) {


### PR DESCRIPTION
## 概要
アプリのメインカラーをデフォルトの紫からオレンジ基調に変更しました。あわせて、ダークモードで一部テキストが黒く見えづらい問題も修正しています。

## 変更内容
- `AppTheme` を新規追加（`ui/theme/Theme.kt`）
  - オレンジ基調のライト/ダーク両方の `ColorScheme` を定義
  - ルートに `Surface` を配置し、ダークモードでコンテンツカラー（色未指定の `Text` など）がテーマに追従するように修正
- `App.kt` で `MaterialTheme` を `AppTheme` に置き換え

## 背景
- これまで `MaterialTheme {}` をカラースキーム未指定で使っていたため、Material3 デフォルトの紫になっていた
- 各画面が `Surface` で囲まれておらず、色未指定テキストの `LocalContentColor` が黒のままでダークモードで見えづらかった

## 動作確認
- Android エミュレーターでリスト/検索/詳細画面を確認し、テキストが明瞭に表示されることを確認
- `./gradlew :composeApp:compileDebugKotlinAndroid` が BUILD SUCCESSFUL

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an app-level theme composable and applied it app-wide to enable automatic light/dark switching.

* **Style**
  * Introduced Material 3 color schemes and applied them across the app, ensuring consistent visuals and proper background handling via themed surfaces.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->