### PR TITLE
Roborazzi + Showkase によるスクリーンショット VRT を導入

### DIFF
--- a/.github/workflows/screenshot-comparison-comment.yml
+++ b/.github/workflows/screenshot-comparison-comment.yml
@@ -1,0 +1,131 @@
+name: Screenshot Comparison Comment
+
+# screenshot-comparison.yml の完了後に実行され、差分画像を companion ブランチへ push して
+# PR にスクリーンショット比較結果をコメントする。差分が解消したらコメントを削除する。
+# PR からのフォーク経由でも安全に書き込み権限を扱えるよう workflow_run トリガーを使う。
+
+on:
+  workflow_run:
+    workflows:
+      - Screenshot Comparison
+    types:
+      - completed
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.head_branch }}-${{ github.event.workflow_run.id }}
+  cancel-in-progress: true
+
+jobs:
+  comment:
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion == 'success'
+
+    timeout-minutes: 5
+
+    permissions:
+      actions: read # artifact のダウンロード用
+      contents: write # companion ブランチへの push 用
+      pull-requests: write # PR へのコメント用
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout main
+        uses: actions/checkout@v6
+        with:
+          ref: main
+
+      - name: Download PR number
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          name: pr
+          run_id: ${{ github.event.workflow_run.id }}
+
+      - id: get-pull-request-number
+        name: Get pull request number
+        shell: bash
+        run: |
+          echo "pull_request_number=$(cat NR)" >> "$GITHUB_OUTPUT"
+
+      - name: Download comparison results
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          run_id: ${{ github.event.workflow_run.id }}
+          name: screenshot-diff-reports
+          path: screenshot-diff-reports
+
+      - id: collect-compare-images
+        name: Collect compare images
+        run: |
+          files=$(find . -type f -name '*_compare.png' | sort)
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "screenshot_compare_images<<${delimiter}"
+            echo "$files"
+            echo "${delimiter}"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Prepare companion branch and outputs
+        id: prepare-companion-branch
+        if: steps.collect-compare-images.outputs.screenshot_compare_images != ''
+        env:
+          BRANCH_NAME: companion_${{ github.event.workflow_run.head_branch }}
+        run: |
+          delimiter="$(openssl rand -hex 8)"
+          {
+            echo "comment_content<<${delimiter}"
+            echo "## Screenshot Comparison Results"
+          } >> "$GITHUB_OUTPUT"
+
+          # orphan ブランチにすることで履歴を持たない比較結果専用ブランチを作る
+          git branch -D "$BRANCH_NAME" || true
+          git checkout --orphan "$BRANCH_NAME"
+          git rm -rf .
+          echo "${{ steps.collect-compare-images.outputs.screenshot_compare_images }}" | while read file; do
+            [ -n "$file" ] && git add "$file"
+            echo "![](https://github.com/${{ github.repository }}/blob/${BRANCH_NAME}/$(echo "${file}" | sed 's|^\./||')?raw=true)" >> "$GITHUB_OUTPUT"
+          done
+          echo "${delimiter}" >> "$GITHUB_OUTPUT"
+          git config --global user.name github-actions[bot]
+          git config --global user.email github-actions[bot]@users.noreply.github.com
+          git commit -m "Add screenshot diff"
+          git push origin HEAD:"$BRANCH_NAME" -f
+
+      - name: Find Comment
+        uses: peter-evans/find-comment@b30e6a3c0ed37e7c023ccd3f1db5c6c0b0c23aad # v4
+        id: fc
+        with:
+          issue-number: ${{ steps.get-pull-request-number.outputs.pull_request_number }}
+          comment-author: 'github-actions[bot]'
+          body-includes: Screenshot Comparison Results
+
+      - name: Add or update comment on PR
+        uses: peter-evans/create-or-update-comment@e8674b075228eee787fea43ef493e45ece1004c9 # v5
+        if: steps.prepare-companion-branch.outputs.comment_content != ''
+        with:
+          comment-id: ${{ steps.fc.outputs.comment-id }}
+          issue-number: ${{ steps.get-pull-request-number.outputs.pull_request_number }}
+          body: ${{ steps.prepare-companion-branch.outputs.comment_content }}
+          edit-mode: replace
+
+      - name: Delete comment when no diff
+        # 差分が無くなったら既存の比較結果コメントを削除する（解消が一目で分かるようにする）
+        if: >
+          steps.collect-compare-images.outputs.screenshot_compare_images == '' &&
+          steps.fc.outputs.comment-id != ''
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh api -X DELETE "/repos/${{ github.repository }}/issues/comments/${{ steps.fc.outputs.comment-id }}"
+
+      - name: Cleanup outdated companion branches
+        run: |
+          # 2 週間以上更新の無い companion ブランチを削除する
+          git branch -r --format="%(refname:lstrip=3)" | grep companion_ | while read -r branch; do
+            last_commit_date_timestamp=$(git log -1 --format=%ct "origin/$branch")
+            now_timestamp=$(date +%s)
+            if [ $((now_timestamp - last_commit_date_timestamp)) -gt 1209600 ]; then
+               git push origin --delete "$branch"
+            fi
+          done

--- a/.github/workflows/screenshot-comparison.yml
+++ b/.github/workflows/screenshot-comparison.yml
@@ -1,0 +1,69 @@
+name: Screenshot Comparison
+
+# PR で、ベースブランチの参照スクリーンショットを取得して現在の UI と比較する。
+# 差分があっても本ジョブは失敗させず、差分画像をレポート artifact として保存する。
+# 実際の差分の可視化（PR へのコメント）は screenshot-comparison-comment.yml が担う。
+
+on:
+  pull_request:
+    branches: [ main ]
+
+jobs:
+  comparison:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Download reference screenshots
+        uses: dawidd6/action-download-artifact@b6e2e70617bc3265edd6dab6c906732b2f1ae151 # v21
+        with:
+          name: expected_screenshots
+          path: composeApp/screenshots
+          workflow: screenshot-record.yml
+          branch: ${{ github.base_ref }}
+          if_no_artifact_found: warn
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Compare screenshots
+        run: ./gradlew :composeApp:compareRoborazziAndroidHostTest
+
+      - name: Upload comparison results
+        uses: actions/upload-artifact@v7
+        with:
+          name: screenshot-diff-reports
+          path: |
+            **/build/reports
+            **/build/outputs/roborazzi
+          retention-days: 30
+
+      - name: Save PR number for comment
+        run: |
+          mkdir -p ./pr
+          echo ${{ github.event.number }} > ./pr/NR
+
+      - name: Upload PR number
+        uses: actions/upload-artifact@v7
+        with:
+          name: pr
+          path: pr/

--- a/.github/workflows/screenshot-record.yml
+++ b/.github/workflows/screenshot-record.yml
@@ -1,0 +1,50 @@
+name: Screenshot Record
+
+# main への push 時に参照スクリーンショットを生成し、artifact として保存する。
+# PR の比較ジョブ（screenshot-comparison.yml）がこの artifact をベースブランチから取得して差分を検出する。
+
+on:
+  push:
+    branches: [ main ]
+
+concurrency:
+  group: screenshot-record-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  record:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v6
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v5
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+
+      - name: Cache Gradle packages
+        uses: actions/cache@v5
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: Record reference screenshots
+        run: ./gradlew :composeApp:recordRoborazziAndroidHostTest
+
+      - name: Upload reference screenshots
+        uses: actions/upload-artifact@v7
+        with:
+          name: expected_screenshots
+          path: composeApp/screenshots/*
+          retention-days: 30

--- a/.gitignore
+++ b/.gitignore
@@ -18,5 +18,8 @@ captures
 !*.xcworkspace/contents.xcworkspacedata
 **/xcshareddata/WorkspaceSettings.xcsettings
 
+# Roborazzi reference screenshots (artifact 経由でやり取りするためコミットしない)
+composeApp/screenshots/
+
 # Claude Code
 settings.local.json

--- a/composeApp/build.gradle.kts
+++ b/composeApp/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     alias(libs.plugins.spotless)
     alias(libs.plugins.ksp)
     alias(libs.plugins.room)
+    alias(libs.plugins.roborazzi)
 }
 
 kotlin {
@@ -30,6 +31,10 @@ kotlin {
         }
 
         withHostTestBuilder {}
+            .configure {
+                // Robolectric が Android リソース/マニフェストを読めるようにする（Roborazzi スクリーンショットテスト用）
+                isIncludeAndroidResources = true
+            }
     }
 
     listOf(
@@ -50,6 +55,10 @@ kotlin {
             implementation(libs.androidx.media3.exoplayer)
             implementation(libs.androidx.media3.session)
             implementation(libs.androidx.media3.ui)
+            // Showkase: Preview を自動列挙してスクリーンショット VRT 対象にする（Android のみ）
+            implementation(libs.showkase)
+            implementation(libs.showkase.annotation)
+            implementation(libs.androidx.compose.ui.tooling.preview)
         }
         iosMain.dependencies {
             implementation(libs.ktor.client.darwin)
@@ -91,6 +100,18 @@ kotlin {
             implementation(libs.kotlinx.coroutines.test)
             implementation(libs.turbine)
         }
+        getByName("androidHostTest").dependencies {
+            // Roborazzi + Robolectric によるスクリーンショット VRT（Android ホストテスト）
+            implementation(libs.junit)
+            implementation(libs.robolectric)
+            implementation(libs.androidx.test.core)
+            implementation(libs.androidx.junit)
+            implementation(libs.androidx.compose.ui.test.junit4)
+            implementation(libs.androidx.compose.ui.test.manifest)
+            implementation(libs.roborazzi)
+            implementation(libs.roborazzi.compose)
+            implementation(libs.roborazzi.rule)
+        }
     }
 }
 
@@ -98,10 +119,17 @@ dependencies {
     add("kspAndroid", libs.room.compiler)
     add("kspIosSimulatorArm64", libs.room.compiler)
     add("kspIosArm64", libs.room.compiler)
+    // Showkase の Preview メタデータを生成（Android のみ）
+    add("kspAndroid", libs.showkase.processor)
 }
 
 room {
     schemaDirectory("$projectDir/schemas")
+}
+
+roborazzi {
+    // 参照画像の出力先（artifact 経由でやり取りするためコミットはしない）
+    outputDir.set(file("screenshots"))
 }
 
 spotless {

--- a/composeApp/src/androidHostTest/kotlin/jp/kztproject/simplepodcastplayer/ShowkaseParameterizedTest.kt
+++ b/composeApp/src/androidHostTest/kotlin/jp/kztproject/simplepodcastplayer/ShowkaseParameterizedTest.kt
@@ -1,0 +1,81 @@
+package jp.kztproject.simplepodcastplayer
+
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.test.onRoot
+import coil3.ColorImage
+import coil3.ImageLoader
+import coil3.SingletonImageLoader
+import coil3.annotation.DelicateCoilApi
+import coil3.test.FakeImageLoaderEngine
+import com.airbnb.android.showkase.models.Showkase
+import com.airbnb.android.showkase.models.ShowkaseBrowserComponent
+import com.github.takahirom.roborazzi.captureRoboImage
+import jp.kztproject.simplepodcastplayer.showcase.getMetadata
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.ParameterizedRobolectricTestRunner
+import org.robolectric.annotation.Config
+import org.robolectric.annotation.GraphicsMode
+
+/**
+ * Showkase が収集した全 Preview コンポーネントを Roborazzi で一括キャプチャするスクリーンショットテスト。
+ *
+ * - `recordRoborazzi*` タスク: 参照画像を `screenshots/` に生成
+ * - `compareRoborazzi*` タスク: 参照画像と比較し差分画像（`*_compare.png`）を生成
+ */
+@GraphicsMode(GraphicsMode.Mode.NATIVE)
+@RunWith(ParameterizedRobolectricTestRunner::class)
+@Config(sdk = [35])
+class ShowkaseParameterizedTest(private val testCase: TestCase) {
+    @get:Rule
+    val composeRule = createComposeRule()
+
+    @OptIn(DelicateCoilApi::class)
+    @Before
+    fun setUpImageLoader() {
+        // 各テストごとに Coil のシングルトンをリセットしてからフェイク ImageLoader を設定する。
+        // これにより、Preview が個別に setSingletonImageLoaderFactory を呼んでも衝突せず、
+        // ネットワークへアクセスせず常に同じプレースホルダ画像で決定的に描画される。
+        SingletonImageLoader.reset()
+        SingletonImageLoader.setSafe { context ->
+            ImageLoader.Builder(context)
+                .components {
+                    add(
+                        FakeImageLoaderEngine.Builder()
+                            .default(ColorImage(0xFF00A3AF.toInt()))
+                            .build(),
+                    )
+                }
+                .build()
+        }
+    }
+
+    @Test
+    fun captureShowkaseComponent() {
+        val component = testCase.showkaseBrowserComponent
+
+        composeRule.setContent {
+            component.component()
+        }
+
+        composeRule
+            .onRoot()
+            .captureRoboImage(
+                filePath = "screenshots/${component.componentName}_${component.group}.png".replace(" ", "_"),
+            )
+    }
+
+    companion object {
+        class TestCase(val showkaseBrowserComponent: ShowkaseBrowserComponent) {
+            override fun toString() = showkaseBrowserComponent.componentKey
+        }
+
+        @ParameterizedRobolectricTestRunner.Parameters(name = "[{index}] {0}")
+        @JvmStatic
+        fun components(): Iterable<Array<*>> = Showkase.getMetadata().componentList.map {
+            arrayOf(TestCase(it))
+        }
+    }
+}

--- a/composeApp/src/androidMain/kotlin/jp/kztproject/simplepodcastplayer/showcase/ScreenPreviews.kt
+++ b/composeApp/src/androidMain/kotlin/jp/kztproject/simplepodcastplayer/showcase/ScreenPreviews.kt
@@ -1,0 +1,56 @@
+package jp.kztproject.simplepodcastplayer.showcase
+
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.tooling.preview.Preview
+import com.airbnb.android.showkase.annotation.ShowkaseComposable
+import jp.kztproject.simplepodcastplayer.screen.InProgressEpisodesScreenEmptyPreview
+import jp.kztproject.simplepodcastplayer.screen.InProgressEpisodesScreenPreview
+import jp.kztproject.simplepodcastplayer.screen.PlayerScreenPreview
+import jp.kztproject.simplepodcastplayer.screen.PodcastDetailScreenPreview
+import jp.kztproject.simplepodcastplayer.screen.PodcastListScreenEmptyPreview
+import jp.kztproject.simplepodcastplayer.screen.PodcastListScreenPreview
+import jp.kztproject.simplepodcastplayer.screen.PodcastSearchScreenWithResultsPreview
+
+// commonMain の CMP Preview は Showkase の自動検出対象外（androidx の @Preview ではないため）。
+// ここで androidx の @Preview + @ShowkaseComposable を付けた薄いラッパーから既存 Preview を呼び出し、
+// Showkase の列挙対象に載せて Roborazzi の VRT 対象にする。サンプルデータは既存 Preview を再利用。
+
+private const val GROUP = "Screens"
+
+@ShowkaseComposable(name = "PodcastList", group = GROUP)
+@Preview
+@Composable
+fun PodcastListShowcase() = PodcastListScreenPreview()
+
+@ShowkaseComposable(name = "PodcastListEmpty", group = GROUP)
+@Preview
+@Composable
+fun PodcastListEmptyShowcase() = PodcastListScreenEmptyPreview()
+
+// PodcastSearchScreenPreview（ステートフル版）は koinViewModel() を使い Koin 起動が必要なため
+// VRT 対象から除外。検索画面は下のステートレス版（WithResults）でカバーする。
+
+@ShowkaseComposable(name = "PodcastSearchWithResults", group = GROUP)
+@Preview
+@Composable
+fun PodcastSearchWithResultsShowcase() = PodcastSearchScreenWithResultsPreview()
+
+@ShowkaseComposable(name = "PodcastDetail", group = GROUP)
+@Preview
+@Composable
+fun PodcastDetailShowcase() = PodcastDetailScreenPreview()
+
+@ShowkaseComposable(name = "Player", group = GROUP)
+@Preview
+@Composable
+fun PlayerShowcase() = PlayerScreenPreview()
+
+@ShowkaseComposable(name = "InProgressEpisodes", group = GROUP)
+@Preview
+@Composable
+fun InProgressEpisodesShowcase() = InProgressEpisodesScreenPreview()
+
+@ShowkaseComposable(name = "InProgressEpisodesEmpty", group = GROUP)
+@Preview
+@Composable
+fun InProgressEpisodesEmptyShowcase() = InProgressEpisodesScreenEmptyPreview()

--- a/composeApp/src/androidMain/kotlin/jp/kztproject/simplepodcastplayer/showcase/ShowkaseModule.kt
+++ b/composeApp/src/androidMain/kotlin/jp/kztproject/simplepodcastplayer/showcase/ShowkaseModule.kt
@@ -1,0 +1,12 @@
+package jp.kztproject.simplepodcastplayer.showcase
+
+import com.airbnb.android.showkase.annotation.ShowkaseRoot
+import com.airbnb.android.showkase.annotation.ShowkaseRootModule
+
+/**
+ * Showkase のルートモジュール。
+ * これを起点に、アプリ内の `@ShowkaseComposable` が付与された Preview を自動収集する。
+ * 収集結果は Roborazzi のスクリーンショットテスト（VRT）で一括キャプチャされる。
+ */
+@ShowkaseRoot
+class ShowkaseModule : ShowkaseRootModule

--- a/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastSearchScreen.kt
+++ b/composeApp/src/commonMain/kotlin/jp/kztproject/simplepodcastplayer/screen/PodcastSearchScreen.kt
@@ -279,7 +279,8 @@ fun PodcastSearchScreenWithResultsPreview() {
             trackViewUrl = "https://example.com/podcast$index",
             artworkUrl100 = "https://example.com/artwork$index.jpg",
             primaryGenreName = if (index % 2 == 0) "Technology" else "Comedy",
-            trackCount = (10..100).random(),
+            // VRT を決定的にするため固定値にする（ランダムだとスクリーンショット差分が毎回発生する）
+            trackCount = index * 10,
         )
     }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -28,6 +28,12 @@ napier = "2.7.1"
 koin = "4.2.1"
 kotlinx-coroutines-test = "1.11.0"
 turbine = "1.2.1"
+roborazzi = "1.63.0"
+showkase = "1.0.5"
+robolectric = "4.16.1"
+androidx-test-core = "1.7.0"
+androidx-junit = "1.3.0"
+androidx-compose-ui = "1.9.4"
 
 [libraries]
 kotlin-test = { module = "org.jetbrains.kotlin:kotlin-test", version.ref = "kotlin" }
@@ -69,6 +75,18 @@ koin-compose-viewmodel = { module = "io.insert-koin:koin-compose-viewmodel", ver
 koin-test = { module = "io.insert-koin:koin-test", version.ref = "koin" }
 kotlinx-coroutines-test = { module = "org.jetbrains.kotlinx:kotlinx-coroutines-test", version.ref = "kotlinx-coroutines-test" }
 turbine = { module = "app.cash.turbine:turbine", version.ref = "turbine" }
+roborazzi = { module = "io.github.takahirom.roborazzi:roborazzi", version.ref = "roborazzi" }
+roborazzi-compose = { module = "io.github.takahirom.roborazzi:roborazzi-compose", version.ref = "roborazzi" }
+roborazzi-rule = { module = "io.github.takahirom.roborazzi:roborazzi-junit-rule", version.ref = "roborazzi" }
+showkase = { module = "com.airbnb.android:showkase", version.ref = "showkase" }
+showkase-annotation = { module = "com.airbnb.android:showkase-annotation", version.ref = "showkase" }
+showkase-processor = { module = "com.airbnb.android:showkase-processor", version.ref = "showkase" }
+robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+androidx-test-core = { module = "androidx.test:core", version.ref = "androidx-test-core" }
+androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
+androidx-compose-ui-test-junit4 = { module = "androidx.compose.ui:ui-test-junit4", version.ref = "androidx-compose-ui" }
+androidx-compose-ui-test-manifest = { module = "androidx.compose.ui:ui-test-manifest", version.ref = "androidx-compose-ui" }
+androidx-compose-ui-tooling-preview = { module = "androidx.compose.ui:ui-tooling-preview", version.ref = "androidx-compose-ui" }
 
 [plugins]
 androidApplication = { id = "com.android.application", version.ref = "agp" }
@@ -82,3 +100,4 @@ kotlinSerialization = { id = "org.jetbrains.kotlin.plugin.serialization", versio
 spotless = { id = "com.diffplug.spotless", version.ref = "spotless" }
 ksp = { id = "com.google.devtools.ksp", version.ref = "ksp" }
 room = { id = "androidx.room", version.ref = "room" }
+roborazzi = { id = "io.github.takahirom.roborazzi", version.ref = "roborazzi" }


### PR DESCRIPTION
## 概要
[RewardedTodo](https://github.com/kseito/RewardedTodo) と同じ **Roborazzi + Showkase** によるスクリーンショット VRT（Visual Regression Testing）の仕組みを、本リポジトリの Kotlin Multiplatform 構成に合わせて導入します。UI 変更時の意図しない見た目の崩れを PR 上で検出・可視化できます。

## 仕組み（3 ワークフロー連動）
1. `screenshot-record.yml`: main への push で参照画像を生成し artifact 化
2. `screenshot-comparison.yml`: PR でベースブランチの参照画像を取得して比較、差分レポートを artifact 化
3. `screenshot-comparison-comment.yml`: 比較完了後に差分画像を companion ブランチへ push し PR にコメント（差分解消時はコメント削除）

## RewardedTodo（純 Android）からの KMP 固有の調整
- Showkase 連携を **androidMain 側**に配置し commonMain / iOS ビルドは無傷（iOS コンパイル成功を確認）
- Roborazzi のタスク名は `recordRoborazziAndroidHostTest` / `compareRoborazziAndroidHostTest`（バリアントベースの `*Debug` ではない）
- `PodcastSearchScreenPreview`（ステートフル・`koinViewModel()` 使用）は Koin 起動が必要なため VRT 対象から除外（検索画面はステートレスの WithResults 版でカバー）
- Coil シングルトンの二重設定を避けるため、テストの `@Before` で `SingletonImageLoader.reset()` + フェイクローダー設定

## VRT 対象（7 画面）
PodcastList / PodcastListEmpty / PodcastSearchWithResults / PodcastDetail / Player / InProgressEpisodes / InProgressEpisodesEmpty

## ローカル検証済み
- `recordRoborazziAndroidHostTest` → 7 画面の参照画像生成、描画も正常
- `compareRoborazziAndroidHostTest` → 差分画像ゼロ（決定的）
- iOS コンパイル成功 / 既存ユニットテスト 82 件成功 / detekt・spotless 通過

## 補足
- 参照画像はコミットせず artifact 経由でやり取り（`.gitignore` に追加済み）
- ワークフローの GitHub 上での連動は、この PR をベースに main へマージして参照画像 artifact ができて初めて完全に機能します

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated screenshot comparison on pull requests to detect unintended UI changes.
  * Visual regression testing with component preview showcase.

* **Tests**
  * Added visual regression test suite for UI components with automated capture and comparison.

* **Chores**
  * Configured CI/CD workflows and necessary testing infrastructure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->