### PR TITLE
Add Claude Code GitHub Actionsワークフロー

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -1,0 +1,38 @@
+name: Claude Code
+
+on:
+  issue_comment:
+    types: [created]
+  pull_request_review_comment:
+    types: [created]
+
+jobs:
+  claude:
+    name: Claude Code
+    runs-on: ubuntu-latest
+    # 公開リポジトリのため、信頼できるユーザー（OWNER / MEMBER / COLLABORATOR）の
+    # @claude コメントのみ実行する。第三者によるAPIクレジット消費を防ぐガード。
+    if: |
+      contains(github.event.comment.body, '@claude') &&
+      (github.event.comment.author_association == 'OWNER' ||
+       github.event.comment.author_association == 'MEMBER' ||
+       github.event.comment.author_association == 'COLLABORATOR')
+    permissions:
+      contents: write
+      pull-requests: write
+      issues: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          fetch-depth: 1
+          persist-credentials: false
+
+      - name: Run Claude Code
+        uses: anthropics/claude-code-action@80b31826338489861333dc17217865dfe8085cdc # v1.0.155
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN }}
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          trigger_phrase: "@claude"
+          claude_args: |
+            --max-turns 15

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -10,9 +10,13 @@ jobs:
   claude:
     name: Claude Code
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     # 公開リポジトリのため、信頼できるユーザー（OWNER / MEMBER / COLLABORATOR）の
     # @claude コメントのみ実行する。第三者によるAPIクレジット消費を防ぐガード。
+    # また issue_comment はIssue/PR両方で発火するため、PR上のコメントに限定する。
     if: |
+      (github.event_name == 'pull_request_review_comment' ||
+       (github.event_name == 'issue_comment' && github.event.issue.pull_request)) &&
       contains(github.event.comment.body, '@claude') &&
       (github.event.comment.author_association == 'OWNER' ||
        github.event.comment.author_association == 'MEMBER' ||


### PR DESCRIPTION
## 概要

`@claude` メンションでオンデマンドにClaude Codeを起動するGitHub Actionsワークフローを追加します。PR上で `@claude このPRをレビューして` のようにコメントすると、Claudeがレビューやコード修正を行います。

## 公開リポジトリ向けのセキュリティ考慮

このリポジトリはPUBLICのため、以下のガードを設けています：

- **信頼ユーザー限定**: `author_association` が `OWNER` / `MEMBER` / `COLLABORATOR` のコメントのみ起動。外部の第三者(`CONTRIBUTOR` / `NONE` 等)は弾かれ、サブスク枠を消費しない
- **`pull_request_target` 不使用**: fork PRのコードをwrite権限で実行する危険な経路を回避
- **トリガー限定**: `issue_comment` / `pull_request_review_comment` の `@claude` メンションのみ（オンデマンド）
- **actionはSHAピン留め**: write権限を持つワークフローのため、タグではなくSHAで固定

## 認証

サブスク(Pro/Max)枠を使う `claude_code_oauth_token` 方式を採用。

## マージ前に必要な手動作業

リポジトリSecret `CLAUDE_CODE_OAUTH_TOKEN` の登録：

\`\`\`
claude setup-token
gh secret set CLAUDE_CODE_OAUTH_TOKEN --repo kseito/SimplePodcastPlayer
\`\`\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new comment-triggered automation for repository discussions and pull request review comments.
  * The automation runs only for authorized contributors and responds when a comment includes a specific trigger phrase.
  * Updated permissions and setup so the workflow can interact with issues and pull requests as needed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->